### PR TITLE
Minor fix for gShouldUseRandomColors

### DIFF
--- a/script.gs
+++ b/script.gs
@@ -383,7 +383,7 @@ function initializeGlobalParametersIfNeeded() {
   gWelcomeStartButton = parametersData[4][1];
   gEndMessage = parametersData[5][1];
   gDoNotUnderstandMessage = parametersData[6][1];
-  gShouldUseRandomColors = parametersData[7][1];
+  gShouldUseRandomColors = parametersData[7][1].toLowerCase() === 'true';
   gDefaultKeyboardColor = parametersData[8][1];
 }
 


### PR DESCRIPTION
The example sheet on Google Drive states that "Should keyboard use random colors" can be TRUE or FALSE, And if FALSE is entered, then gShouldUseRandomColors would be "FALSE". And that would result in incorrect evaluation [here](https://github.com/Viber/build-a-bot-with-zero-coding/blob/10594b545cb5f05de6461696139d18241006e76a/script.gs#L246)